### PR TITLE
Copy files into directories and don't overwrite them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM golang:1.15 as build
 WORKDIR /go/src/github.com/webdevops/alertmanager2es
 
 # Get deps (cached)
-COPY ./go.mod /go/src/github.com/webdevops/alertmanager2es
-COPY ./go.sum /go/src/github.com/webdevops/alertmanager2es
-COPY ./Makefile /go/src/github.com/webdevops/alertmanager2es
+COPY ./go.mod /go/src/github.com/webdevops/alertmanager2es/
+COPY ./go.sum /go/src/github.com/webdevops/alertmanager2es/
+COPY ./Makefile /go/src/github.com/webdevops/alertmanager2es/
 RUN make dependencies
 
 # Compile
-COPY ./ /go/src/github.com/webdevops/alertmanager2es
+COPY ./ /go/src/github.com/webdevops/alertmanager2es/
 RUN make test
 RUN make lint
 RUN make build


### PR DESCRIPTION
When building with podman instead of Docker the destination folder of COPY should contain the final slash otherwise it doesn't work as expected. 